### PR TITLE
Extend wheel package manager capaibilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ dist: clean
 deploy-lib: dist
 	@echo "Deploying $(DIST_VERSION) lib to device"
 	@$(MPREMOTE_CMD) mount . run scripts/mount_enforcer.py run scripts/deploy_wheel.py
+	@echo "Deployment succeeded, resetting device"
+	@$(MPREMOTE_CMD) reset
 
 .PHONY: purge-lib
 purge-lib:

--- a/mpy_blox/wheel/__init__.py
+++ b/mpy_blox/wheel/__init__.py
@@ -3,11 +3,55 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import logging
+import re
+import uos
 
 from mpy_blox.os import makedirs
+from mpy_blox.wheel.info import WheelPackage
+
+DIST_INFO_RE = re.compile(
+    r"^(((.+?)-(.+?))(-(P\d[^-]*))?.dist-info/?)(RECORD$)?")
+
+DEFAULT_PREFIX = '/lib/'
+
+class WheelExistingInstallation(Exception):
+    def __init__(self, pkg):
+        super().__init__("Found existing installation: {}".format(pkg))
+        self.existing_pkg = pkg
 
 
-def install(wheel_file, prefix='/lib/'):
+def read_package(dist_info_path):
+    with open(dist_info_path + '/METADATA', 'rt') as metadata_f:
+        pep314_metadata = metadata_f.read()
+    with open(dist_info_path + '/RECORD', 'rt') as record_f:
+        record_contents = record_f.read()
+
+    return WheelPackage(pep314_metadata, record_contents)
+
+
+def list_installed(prefix=None):
+    prefix = prefix or DEFAULT_PREFIX
+    dist_info_re = DIST_INFO_RE
+    for subfolder in uos.listdir(prefix):
+        m = dist_info_re.match(subfolder)
+        if m:
+            dist_info_path = prefix + m.group(1)
+            yield read_package(dist_info_path)
+
+
+def pkg_info(name, prefix=None):
+    prefix = prefix or DEFAULT_PREFIX
+    for pkg in list_installed(prefix):
+        if pkg.name == name:
+            return pkg
+
+
+def install(wheel_file, prefix=None):
+    prefix = prefix or DEFAULT_PREFIX
+    existing_pkg = pkg_info(wheel_file.package.name, prefix)
+    if existing_pkg:
+        raise WheelExistingInstallation(existing_pkg)
+
     for name, record_entry in wheel_file.wheel_record.items():
         output_path = prefix + name
         logging.info("%s -> %s", name, output_path)

--- a/mpy_blox/wheel/info.py
+++ b/mpy_blox/wheel/info.py
@@ -19,6 +19,17 @@ class WheelRecordEntry:
 
         self.size =  int(size) if size else None
 
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+
+        if self.checksum is None:
+            return False
+
+        return (self.name == other.name
+                and self.checksum_algo == other.checksum_algo
+                and self.checksum == other.checksum)
+
     @property
     def checksum_hasher(self):
         algo = self.checksum_algo

--- a/mpy_blox/wheel/info.py
+++ b/mpy_blox/wheel/info.py
@@ -1,0 +1,84 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import uhashlib
+from ucollections import OrderedDict
+
+from mpy_blox.base64 import urlsafe_b64decode, urlsafe_b64encode
+
+
+class WheelRecordEntry:
+    def __init__(self, record_line):
+        self.name, checksum_line, size = record_line.rsplit(',', 2)
+
+        self.checksum = self.checksum_algo = None
+        if checksum_line:
+            self.checksum_algo, encoded_checksum = checksum_line.split('=', 1)
+            self.checksum = urlsafe_b64decode(encoded_checksum)
+
+        self.size =  int(size) if size else None
+
+    @property
+    def checksum_hasher(self):
+        algo = self.checksum_algo
+        return getattr(uhashlib, algo) if algo else None
+
+    def __str__(self):
+        return ("<WheelRecordEntry name="
+                "{}, checksum_algo={}, checksum={}>".format(
+                    self.name,
+                    self.checksum_algo,
+                    urlsafe_b64encode(self.checksum) if self.checksum else None
+                ))
+
+
+class WheelMetadata:
+    def __init__(self, pep314_metadata):
+        self.parsed_metadata = OrderedDict()
+        for line in pep314_metadata.splitlines():
+            key, value = line.split(':', 1)
+            self.parsed_metadata[key] = value.strip()
+
+    def __getitem__(self, k):
+        return self.parsed_metadata[k]
+
+
+class WheelRecord:
+    def __init__(self, record_contents):
+        self.parsed_record = parsed_record = OrderedDict()
+        for line in record_contents.splitlines():
+            record_entry = WheelRecordEntry(line)
+            parsed_record[record_entry.name] = record_entry
+
+    def __getitem__(self, k):
+        return self.parsed_record[k]
+
+    def __iter__(self):
+        yield from self.parsed_record
+
+    def items(self):
+        yield from self.parsed_record.items()
+
+    def __str__(self):
+        return "<WheelRecord num_entries={}>".format(len(self.parsed_record))
+
+
+class WheelPackage:
+    def __init__(self, pep314_metadata, record_contents):
+        self.metadata = WheelMetadata(pep314_metadata)
+        self.wheel_record = WheelRecord(record_contents)
+
+    @property
+    def name(self):
+        return self.metadata['Name']
+
+    @property
+    def version(self):
+        return self.metadata['Version']
+
+    def __str__(self):
+        return "<WheelPackage name={}, version={}, wheel_record={}>".format(
+            self.name,
+            self.version,
+            self.wheel_record)

--- a/scripts/deploy_wheel.py
+++ b/scripts/deploy_wheel.py
@@ -4,7 +4,7 @@
 
 import logging
 
-from mpy_blox.wheel import install
+import mpy_blox.wheel as wheel
 from mpy_blox.wheel.wheelfile import WheelFile
 
 logging.basicConfig(level=logging.INFO)
@@ -12,4 +12,11 @@ logging.basicConfig(level=logging.INFO)
 logging.info("Opening WheelFile")
 with open('/remote/dist/mpy_blox-latest-mpy-bytecode-esp32.whl', 'rb') as f:
     wheel_file = WheelFile(f)
-    install(wheel_file)
+    try:
+        wheel.install(wheel_file)
+    except wheel.WheelExistingInstallation as ex_install_exc:
+        logging.info("Force upgrading existing installation "
+                     "{} -> {}".format(
+                         ex_install_exc.existing_pkg.metadata['Version'],
+                         wheel_file.package.metadata['Version']))
+        wheel.upgrade(ex_install_exc.existing_pkg, wheel_file)


### PR DESCRIPTION
* Parses package metata
* Allows listing installed wheels
* Prevent overwriting, wearing out flash, and allow upgrade of wheel packages from newer whl-files, using record comparison.